### PR TITLE
build(composer): Fix license identifier

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "theme"
     ],
     "homepage": "https://quai10.org/",
-    "license": "GPL-3.0",
+    "license": "GPL-3.0-only",
     "authors": [
         {
             "name": "Pierre Rudloff",


### PR DESCRIPTION
Composer a modifié légèrement la façon d'indiquer la licence GPL et du coup il faut qu'on change si on veut pouvoir continuer à installer le thème avec Composer parce qu'actuellement ça génère une erreur:
```
Skipped branch develop, Invalid package information: 
License "GPL-3.0" is a deprecated SPDX license identifier, use "GPL-3.0-only" or "GPL-3.0-or-later" instead
```